### PR TITLE
feature: Add configuration matrix.room to send messages to

### DIFF
--- a/matrixbridge.properties.template
+++ b/matrixbridge.properties.template
@@ -1,3 +1,4 @@
 matrix.id=@username:domain.com
 matrix.password=
+# matrix.room=!roomID:domain.com
 minecraft.server.name=Server

--- a/src/main/java/at/overflow/bukkit/matrixbridge/BridgePropertyReader.java
+++ b/src/main/java/at/overflow/bukkit/matrixbridge/BridgePropertyReader.java
@@ -9,6 +9,7 @@ public class BridgePropertyReader {
 
     private final String MATRIX_USERID_KEY = "matrix.id";
     private final String MATRIX_PASSWORD_KEY = "matrix.password";
+    private final String MATRIX_ROOMID = "matrix.room";
 
     private final String MINECRAFT_SERVER_NAME_KEY = "minecraft.server.name";
 
@@ -62,5 +63,10 @@ public class BridgePropertyReader {
     public String getPassword() {
         String tmp = properties.getProperty(MATRIX_PASSWORD_KEY);
         return tmp;
+    }
+
+    public String getRoom() {
+      String tmp = properties.getProperty(MATRIX_ROOMID);
+      return tmp;
     }
 }

--- a/src/main/java/at/overflow/bukkit/matrixbridge/BridgeService.java
+++ b/src/main/java/at/overflow/bukkit/matrixbridge/BridgeService.java
@@ -66,13 +66,20 @@ public class BridgeService extends Thread implements Endpoint {
                 for (_SyncData.JoinedRoom joinedRoom : data.getRooms().getJoined()) {
                     _MatrixRoom room = client.getRoom(joinedRoom.getId());
 
+		    if((properties.getRoom() != null)
+		       && !room.getAddress().contentEquals(properties.getRoom())) {
+		      continue;
+		    }
+
                     for (_MatrixEvent rawEv : joinedRoom.getTimeline().getEvents()) {
                         if ("m.room.message".contentEquals(rawEv.getType())) {
                             MatrixJsonRoomMessageEvent msg = new MatrixJsonRoomMessageEvent(rawEv.getJson());
 
+			    // Ignore own messages
                             if (properties.getDomain().equals(msg.getSender().getDomain()) && properties.getUsername().equals(msg.getSender().getLocalPart()))
                                 continue;
 
+			    // Process messages with body
                             if (msg.getBody() != null) {
                                 if (msg.getBody().startsWith("!")) {
                                     this.parseCommand(msg.getBody());
@@ -107,7 +114,11 @@ public class BridgeService extends Thread implements Endpoint {
     public void send(String from, String message) {
         message = message.replaceAll("<", "&lt;").replaceAll(">", "&gt;");
         for (_MatrixRoom room : client.getJoinedRooms()) {
-            room.sendFormattedText("<font color='green'>&lt;" + from + "&gt;</font> " + message, message);
+	  if((properties.getRoom() != null)
+	     && !room.getAddress().contentEquals(properties.getRoom())) {
+	    continue;
+	  }
+	  room.sendFormattedText("<font color='green'>&lt;" + from + "&gt;</font> " + message, message);
         }
     }
 


### PR DESCRIPTION
This PR adds the *optional* configuration `matrix.room`, where a room ID can be specified. Only this room will be used to send messages to, preventing the matrix account from undesired spamming to wrong channels.

The bridge *won't* join or create that room, this still needs to be done by hand (as before). 