### PR TITLE
Small Features/Fixes

### DIFF
--- a/src/main/java/at/overflow/bukkit/matrixbridge/BridgePropertyReader.java
+++ b/src/main/java/at/overflow/bukkit/matrixbridge/BridgePropertyReader.java
@@ -9,7 +9,7 @@ public class BridgePropertyReader {
 
     private final String MATRIX_USERID_KEY = "matrix.id";
     private final String MATRIX_PASSWORD_KEY = "matrix.password";
-    private final String MATRIX_ROOMID = "matrix.room";
+    private final String MATRIX_ROOMID_KEY = "matrix.room";
 
     private final String MINECRAFT_SERVER_NAME_KEY = "minecraft.server.name";
 
@@ -66,7 +66,7 @@ public class BridgePropertyReader {
     }
 
     public String getRoom() {
-      String tmp = properties.getProperty(MATRIX_ROOMID);
+      String tmp = properties.getProperty(MATRIX_ROOMID_KEY);
       return tmp;
     }
 }

--- a/src/main/java/at/overflow/bukkit/matrixbridge/BridgeService.java
+++ b/src/main/java/at/overflow/bukkit/matrixbridge/BridgeService.java
@@ -23,7 +23,7 @@ public class BridgeService extends Thread implements Endpoint {
     private void parseCommand(String body) {
         if(body.startsWith("!players")) {
             sendAllPlayers();
-        }
+	}
     }
 
     private void sendAllPlayers() {
@@ -87,6 +87,7 @@ public class BridgeService extends Thread implements Endpoint {
                                     this.receiver.send(msg.getSender().getId(), msg.getBody());
                                 }
                             }
+			    room.sendReadReceipt(msg.getId());
                         }
                     }
                 }

--- a/src/main/java/at/overflow/bukkit/matrixbridge/MatrixPlugin.java
+++ b/src/main/java/at/overflow/bukkit/matrixbridge/MatrixPlugin.java
@@ -47,7 +47,7 @@ public class MatrixPlugin extends JavaPlugin implements Listener, Endpoint {
 
     @EventHandler
     public void chat(AsyncPlayerChatEvent e){
-        this.receiver.send(e.getPlayer().getDisplayName(), e.getMessage());
+        this.receiver.send(e.getPlayer().getName(), e.getMessage());
     }
 
     @EventHandler


### PR DESCRIPTION
This PR contains 3 small improvements:

 - All processed messages on the matrix-side will get a read receipt. This gives a small indicator on whether the server is up and running correctly
 - It changes the name of one constant to fit in line with the other ones
 - It replaces the deprecated function `getDisplayName` with `getName` (deprecated by `paper-api`)
