### PR TITLE
Add Event handlers for PlayerDeathEvent and TimeSkipEvent

### DIFF
--- a/src/main/java/at/overflow/bukkit/matrixbridge/MatrixPlugin.java
+++ b/src/main/java/at/overflow/bukkit/matrixbridge/MatrixPlugin.java
@@ -10,6 +10,7 @@ import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.server.ServerCommandEvent;
+import org.bukkit.event.world.TimeSkipEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.util.Collection;
@@ -54,6 +55,13 @@ public class MatrixPlugin extends JavaPlugin implements Listener, Endpoint {
     @EventHandler
     public void death(PlayerDeathEvent e){
       this.receiver.send(e.getPlayer().getName(), e.getDeathMessage());
+    }
+
+    @EventHandler
+    public void sleep(TimeSkipEvent e){
+      if(e.getSkipReason() == TimeSkipEvent.SkipReason.NIGHT_SKIP){
+	this.receiver.send(this.properties.getMinecraftServerName(), "Everyone went to bed");
+      }
     }
 
     @EventHandler

--- a/src/main/java/at/overflow/bukkit/matrixbridge/MatrixPlugin.java
+++ b/src/main/java/at/overflow/bukkit/matrixbridge/MatrixPlugin.java
@@ -5,6 +5,7 @@ import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
@@ -48,6 +49,11 @@ public class MatrixPlugin extends JavaPlugin implements Listener, Endpoint {
     @EventHandler
     public void chat(AsyncPlayerChatEvent e){
         this.receiver.send(e.getPlayer().getDisplayName(), e.getMessage());
+    }
+
+    @EventHandler
+    public void death(PlayerDeathEvent e){
+      this.receiver.send(e.getPlayer().getName(), e.getDeathMessage());
     }
 
     @EventHandler


### PR DESCRIPTION
This PR adds messages for both `PlayerDeathEvent` and `TimeSkipEvent`, so that the matrix-side of the bridge gets a notification when either all players went to bed or a player dies.

I think this PR is slightly opinionated, as it introduces some constant strings ("Everyone went to bed"). I don't know whether the server messages ("$Player joined/quit the game") can be configured to be non-english, so it *might* be unpleasant if it is the case.