### PR TITLE
Feature: admin commands

### DIFF
--- a/matrixbridge.properties.template
+++ b/matrixbridge.properties.template
@@ -1,4 +1,5 @@
 matrix.id=@username:domain.com
 matrix.password=
 # matrix.room=!roomID:domain.com
+matrix.admin=
 minecraft.server.name=Server

--- a/src/main/java/at/overflow/bukkit/matrixbridge/BridgePropertyReader.java
+++ b/src/main/java/at/overflow/bukkit/matrixbridge/BridgePropertyReader.java
@@ -9,7 +9,7 @@ public class BridgePropertyReader {
 
     private final String MATRIX_USERID_KEY = "matrix.id";
     private final String MATRIX_PASSWORD_KEY = "matrix.password";
-    private final String MATRIX_ROOMID = "matrix.room";
+    private final String MATRIX_ROOMID_KEY = "matrix.room";
 
     private final String MINECRAFT_SERVER_NAME_KEY = "minecraft.server.name";
 
@@ -66,7 +66,7 @@ public class BridgePropertyReader {
     }
 
     public String getRoom() {
-      String tmp = properties.getProperty(MATRIX_ROOMID);
+      String tmp = properties.getProperty(MATRIX_ROOMID_KEY);
       return tmp;
     }
 }

--- a/src/main/java/at/overflow/bukkit/matrixbridge/BridgePropertyReader.java
+++ b/src/main/java/at/overflow/bukkit/matrixbridge/BridgePropertyReader.java
@@ -10,6 +10,7 @@ public class BridgePropertyReader {
     private final String MATRIX_USERID_KEY = "matrix.id";
     private final String MATRIX_PASSWORD_KEY = "matrix.password";
     private final String MATRIX_ROOMID_KEY = "matrix.room";
+    private final String MATRIX_ADMINID_KEY = "matrix.admin";
 
     private final String MINECRAFT_SERVER_NAME_KEY = "minecraft.server.name";
 
@@ -33,6 +34,7 @@ public class BridgePropertyReader {
     private void generateEmptyFile(File file) {
             properties.setProperty(MATRIX_USERID_KEY, "");
             properties.setProperty(MATRIX_PASSWORD_KEY, "");
+            properties.setProperty(MATRIX_ADMINID_KEY, "");
             properties.setProperty(MINECRAFT_SERVER_NAME_KEY, "Server");
         try {
             properties.store(new FileOutputStream(file), "Matrix Bridge Properties");
@@ -45,28 +47,27 @@ public class BridgePropertyReader {
 
     public String getDomain() {
         String tmp = properties.getProperty(MATRIX_USERID_KEY);
-
         return tmp.substring(tmp.indexOf(":") + 1);
     }
 
     public String getUsername() {
         String tmp = properties.getProperty(MATRIX_USERID_KEY);
-
         return tmp.substring(1, tmp.indexOf(":"));
     }
 
     public String getMinecraftServerName() {
-        String tmp = properties.getProperty(MINECRAFT_SERVER_NAME_KEY);
-        return tmp;
+        return properties.getProperty(MINECRAFT_SERVER_NAME_KEY);
     }
 
     public String getPassword() {
-        String tmp = properties.getProperty(MATRIX_PASSWORD_KEY);
-        return tmp;
+        return properties.getProperty(MATRIX_PASSWORD_KEY);
     }
 
     public String getRoom() {
-      String tmp = properties.getProperty(MATRIX_ROOMID_KEY);
-      return tmp;
+      return properties.getProperty(MATRIX_ROOMID_KEY);
     }
+
+  public String getAdmin() {
+      return properties.getProperty(MATRIX_ADMINID_KEY);
+  };
 }


### PR DESCRIPTION
This PR adds a configuration `matrix.admin`, supposed to match a matrix ID.
This user is granted server-level command execution, i.e. that user is able to send messages like `/op username` to be executed on the minecraft server (The message you'd send in Element is `//op username`, as single-slash commands are reserved for matrix).

My motivation for this feature was that it enables administration from every matrix client (phone, web browser, etc) without making it necessary to join or even `op` your own user.

This PR has a copy of a commit found in #8 ( 254c09c ), because I wasn't able to split the hunks further apart so that git allows cherry-picking the feature commit.
